### PR TITLE
feat: add RSS Tag-based authentication for feed ownership in Follow

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -115,5 +115,10 @@
     "microsoftClarity": {
       "projectId": ""
     }
+  },
+  "follow":{
+    "enable": false,
+    "feedId":"",
+    "userId":""
   }
 }

--- a/src/content/posts/guide.md
+++ b/src/content/posts/guide.md
@@ -146,6 +146,12 @@ pnpm preview
     "microsoftClarity": {
       "projectId": ""
     }
+  },
+  //如果需要在 Follow(https://follow.is) 中认证订阅源，将 enable 修改为 true，并填写 feedId、userId
+  ”follow“:{
+    ”enable“: false,
+    ”feedId“:”“,
+    ”userId“:”“
   }
 }
 ```

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,10 +1,24 @@
 import type { APIContext } from 'astro'
 import rss from '@astrojs/rss'
-import { site } from '@/config.json'
+import { site, follow } from '@/config.json'
 import { getSortedPosts } from '@/utils/content'
 
 export async function GET(context: APIContext) {
   const sortedPosts = await getSortedPosts()
+  
+  const generateCustomData = () => {
+    let customData = `<language>${site.lang}</language>\n`
+    
+    if (follow?.enable && follow.feedId && follow.userId) {
+      customData += `
+    <follow_challenge>
+      <feedId>${follow.feedId}</feedId>
+      <userId>${follow.userId}</userId>
+    </follow_challenge>`
+    }
+    
+    return customData
+  }
 
   return rss({
     title: site.title,
@@ -16,6 +30,6 @@ export async function GET(context: APIContext) {
       pubDate: post.data.date,
       description: post.data.summary,
     })),
-    customData: `<language>${site.lang}</language>`,
+    customData: generateCustomData(),
   })
 }


### PR DESCRIPTION
[Follow](https://follow.is)

- Implemented RSS Tag-based authentication to verify feed ownership in Follow (https://follow.is).
- Only the RSS Tag method was considered, while the other two options were not implemented.
- Updated RSS generation logic to support ownership claim verification via RSS tags.